### PR TITLE
Don't crash when path is not a String

### DIFF
--- a/app/mixins/page_support.rb
+++ b/app/mixins/page_support.rb
@@ -9,7 +9,7 @@ module PageSupport
   
   # before_filter to set @page
   def set_page
-    path = params[:path] || request.path
+    path = (params[:path] || request.path).to_s
     path = "/#{path}" if !path.start_with?('/')
     @page = Page.all.detect{|p| p.url == path}
     


### PR DESCRIPTION
Circumvent a problem where someone makes a requests so that we cannot rely on path being a String.
