### PR TITLE
View lookup by association type

### DIFF
--- a/core/app/views/brightcontent/base/form_fields/_belongs_to.html.erb
+++ b/core/app/views/brightcontent/base/form_fields/_belongs_to.html.erb
@@ -1,0 +1,1 @@
+<%= form.association field.to_sym %>

--- a/core/app/views/brightcontent/base/form_fields/_has_and_belongs_to_many.html.erb
+++ b/core/app/views/brightcontent/base/form_fields/_has_and_belongs_to_many.html.erb
@@ -1,0 +1,1 @@
+<%= form.association field.to_sym, as: :check_boxes %>

--- a/core/app/views/brightcontent/base/form_fields/_has_many.html.erb
+++ b/core/app/views/brightcontent/base/form_fields/_has_many.html.erb
@@ -1,0 +1,1 @@
+<%= form.association field.to_sym, as: :check_boxes %>

--- a/core/app/views/brightcontent/base/list_fields/_has_and_belongs_to_many.html.erb
+++ b/core/app/views/brightcontent/base/list_fields/_has_and_belongs_to_many.html.erb
@@ -1,0 +1,1 @@
+<%= item.send(field).count %>

--- a/core/app/views/brightcontent/base/list_fields/_has_many.html.erb
+++ b/core/app/views/brightcontent/base/list_fields/_has_many.html.erb
@@ -1,0 +1,1 @@
+<%= item.send(field).count %>

--- a/core/lib/brightcontent/view_lookup.rb
+++ b/core/lib/brightcontent/view_lookup.rb
@@ -1,6 +1,6 @@
 module Brightcontent
   module ViewLookup
-    autoload :Abstract, 'brightcontent/view_lookup/abstract'
+    autoload :Base, 'brightcontent/view_lookup/base'
     autoload :FormField, 'brightcontent/view_lookup/form_field'
     autoload :ListField, 'brightcontent/view_lookup/list_field'
     autoload :FilterField, 'brightcontent/view_lookup/filter_field'

--- a/core/lib/brightcontent/view_lookup/filter_field.rb
+++ b/core/lib/brightcontent/view_lookup/filter_field.rb
@@ -1,16 +1,12 @@
 module Brightcontent
   module ViewLookup
-    class FilterField < Abstract
+    class FilterField < Base
       def render_default
         raise "invalid filter field: #{options[:field]}" unless field_name
         [
           options[:form].label(:"#{field_name}_eq", options[:field].humanize),
           options[:form].select(:"#{field_name}_eq", select_options, {include_blank: true}, class: "form-control input-sm")
         ].join(" ").html_safe
-      end
-
-      def field_type
-        resource_class.columns_hash[options[:field]].try :type
       end
 
       private
@@ -43,14 +39,6 @@ module Brightcontent
 
       def raw_options
         resource_class.uniq.pluck(field_name)
-      end
-
-      def association
-        resource_class.reflect_on_association options[:field].to_sym
-      end
-
-      def resource_class
-        view_context.send :resource_class
       end
     end
   end

--- a/core/lib/brightcontent/view_lookup/form_field.rb
+++ b/core/lib/brightcontent/view_lookup/form_field.rb
@@ -1,6 +1,6 @@
 module Brightcontent
   module ViewLookup
-    class FormField < Abstract
+    class FormField < Base
       def render_default
         options[:form].input(options[:field].to_sym)
       end

--- a/core/lib/brightcontent/view_lookup/list_field.rb
+++ b/core/lib/brightcontent/view_lookup/list_field.rb
@@ -1,12 +1,8 @@
 module Brightcontent
   module ViewLookup
-    class ListField < Abstract
+    class ListField < Base
       def render_default
         view_context.strip_tags(field_value.to_s).truncate(50)
-      end
-
-      def field_type
-        options[:item].column_for_attribute(options[:field]).try(:type)
       end
     end
   end

--- a/core/spec/lib/brightcontent/view_lookup/base_spec.rb
+++ b/core/spec/lib/brightcontent/view_lookup/base_spec.rb
@@ -1,19 +1,20 @@
-require 'brightcontent/view_lookup/abstract'
+require 'brightcontent/view_lookup/base'
 
 module Brightcontent::ViewLookup
-  describe Abstract do
-    class FakeFormField < Abstract
+  describe Base do
+    class FakeFormField < Base
       def field_type
         :string
       end
     end
 
-    let(:view_context) { double(:view_context) }
+    let(:resource_class) { double(:resource_class, reflect_on_association: nil) }
+    let(:view_context) { double(:view_context, resource_class: resource_class) }
     let(:item) { double(:item, name: 'Item name') }
     let(:fake_form_field) { FakeFormField.new(view_context, field: 'name', item: item) }
 
     context 'with specific field partial' do
-      it 'renders the parial' do
+      it 'renders the partial' do
         expect(view_context).to receive(:render_if_exists)
           .with("fake_form_field_name", {field: 'name', item: item}) { "Result" }
         fake_form_field.call
@@ -21,10 +22,20 @@ module Brightcontent::ViewLookup
     end
 
     context 'with specific field type partial' do
-      it 'renders the parial' do
+      it 'renders the partial' do
         expect(view_context).to receive(:render_if_exists).once
         expect(view_context).to receive(:render_if_exists)
           .with("brightcontent/base/fake_form_fields/string", {field: 'name', item: item}) { "Result" }
+        fake_form_field.call
+      end
+    end
+
+    context 'with association type' do
+      it 'renders the partial' do
+        allow(resource_class).to receive(:reflect_on_association).with(:name) { double(macro: "has_one") }
+        expect(view_context).to receive(:render_if_exists).twice
+        expect(view_context).to receive(:render_if_exists)
+          .with("brightcontent/base/fake_form_fields/has_one", {field: 'name', item: item}) { "Result" }
         fake_form_field.call
       end
     end


### PR DESCRIPTION
Allows you to specify list, filter and form views by association type / macro name (`belongs_to`, etc.) This allows for a default form behavior for `belongs_to` with a dropdown, and perhaps some other nice ones in the future.

I also did some refactoring of the `ViewLookup` classes.
