### PR TITLE
fix for undefined resource_class

### DIFF
--- a/core/app/views/brightcontent/application/_resource.html.erb
+++ b/core/app/views/brightcontent/application/_resource.html.erb
@@ -1,3 +1,3 @@
-<li class="<%= 'active' if resource_class == resource.klass %>">
+<li class="<%= 'active' if defined?(resource_class) && resource_class == resource.klass %>">
   <%= link_to nominative_plural(resource.klass).capitalize, root_path + resource.path %>
 </li>


### PR DESCRIPTION
li.active depends on resource_class being defined, but that is apparently
not the case when one is not logged in. (This happens in one of our projects.)

Adding a simple test completely resolves the problem.
