### PR TITLE
Rename bcrypt-ruby to bcrypt to avoid post-install warning

### DIFF
--- a/core/brightcontent-core.gemspec
+++ b/core/brightcontent-core.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "rails", ">= 4.0.0"
-  s.add_dependency "bcrypt-ruby"
+  s.add_dependency "bcrypt"
   s.add_dependency "bootstrap-sass", ">= 3.1"
   s.add_dependency "bootstrap-wysihtml5-rails", ">= 0.3.2"
   s.add_dependency "coffee-rails"


### PR DESCRIPTION
bcrypt-ruby tells us to do so after installing through bundler:

  Post-install message from bcrypt-ruby:

  The bcrypt-ruby gem has changed its name to just bcrypt.  Instead of
  installing `bcrypt-ruby`, you should install `bcrypt`.  Please update your
  dependencies accordingly.
