### PR TITLE
Require Rails < 4.2 as inherited_resources is not compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Brightcontent, yet another rails CMS / admin panel
 * No standard 'cms-modules', we hate those, making custom is easy enough
 * Built in the rails way, use your normals models, only controllers and views are provided
 * Only exception: Page model is provided with tree structure, sorting, hidden and pretty urls like `/services/cleaning/houses`
-* Rails 4 only
+* Rails 4 only (currently >= 4.2 is not supported)
 * Strong Parameters support
 
 ![Brightcontent preview](doc/browser.jpg)

--- a/core/brightcontent-core.gemspec
+++ b/core/brightcontent-core.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency "rails", ">= 4.0.0"
+  s.add_dependency "rails", ">= 4.0.0", "< 4.2"
   s.add_dependency "bcrypt"
   s.add_dependency "bootstrap-sass", ">= 3.1"
   s.add_dependency "bootstrap-wysihtml5-rails", ">= 0.3.2"


### PR DESCRIPTION
The inherited_resources gem is not compatible with Rails 4.2, as responders have been taken out of Rails. Brightcontent requires Rails >= 4.0.0 and inherited_resources ~> 1.4.1, meaning that with a clean install it currently would try to load Rails 4.2, resulting in `NameError: uninitialized constant ActionController::Responder`. Here's what we could do:

- Ditch the deprecated inherited_resources gem (#22)
- Require inherited_resources' `rails-4-2` branch, but I'm not sure how stable it is

Until either of the options above is implemented brightcontent breaks down when used in Rails 4.2 projects. This PR restricts its dependency on Rails to version < 4.2, in order to prevent unexpected errors.