### PR TITLE
Custom filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,82 @@ To add the resource to brightcontent run:
 
 Gratz! Projects can now be controlled with Brightcontent.
 
+Filters
+-------
+
+Using `filter_fields` you may define filters for your index pages:
+
+```ruby
+class BlogsController < Brightcontent::BaseController
+  filter_fields :author, :name
+end
+```
+
+The above will render two filters on the blogs index page. Blog belongs to Author, therefore by default the filter is displayed as a drop-down list containing all authors that have blogs. The name-filter is displayed as a drop-down list containing all values for the `name` attribute found in the blogs table.
+
+### Options
+
+In order to control the way filters are displayed and how they behave you can supply options:
+
+```ruby
+# Supplying options:
+filter_fields author: { ... }, name: { ... }
+
+# Combining filters without options and filters with options:
+filter_fields :author, name: { ... }
+```
+
+Basically all options are delegated to `SimpleForm::FormBuilder#input`, such as `:as`, `:input_html`, and `:label_method`. Refer to [Simple Form's documentation](http://www.rubydoc.info/github/plataformatec/simple_form/master/SimpleForm/FormBuilder#input-instance_method) for more information.
+
+#### Other options
+
+##### <tt>:collection</tt>
+
+Extends SimpleForm's `:collection` option. It also accepts a Proc, or method name as a symbol. It defaults to either a list of all existing values for the corresponding attribute or a list of all associated records in case of a belongs-to relationship.
+
+##### <tt>:predicate</tt>
+
+Allows for specifying the Ransack search predicate to be used. Defaults to "cont" (contains) for string type filters (`:string` or `:search`) and to "eq" (equals) for all other types. For more information refer to [Ransack's documentation](https://github.com/activerecord-hackery/ransack/wiki/Basic-Searching).
+
+### Examples
+
+```ruby
+class BlogsController < Brightcontent::BaseController
+  # Two default drop-down list filters:
+  filter_fields :name, :author
+
+  # Free form text filter, returns all blogs where name contains given query:
+  filter_fields name: { as: :string, predicate: "cont" }
+
+  # Same as above:
+  filter_fields name: { as: :string }
+
+  # Customized label:
+  filter_fields author: { label: "Written by" }
+
+  # Select filter with custom options:
+  filter_fields name: { collection: ["Game reviews", "Programming tips", "Arthur's blog"] }
+
+  # Belongs-to filter with custom options:
+  filter_fields author: { collection: ->{ Author.order(:name) }, label_method: :display_name }
+
+  # Or by means of a controller method:
+  filter_fields author: { collection: :published_authors }
+
+  # Or even a fully customized filter, using a fictitious custom SimpleForm input field:
+  filter_fields author: { as: :remote_select, url: "/authors.json?order=name" }
+
+  # Filter by start date:
+  filter_fields created_at: { as: :date, predicate: "gteq", label: "Posted since" }
+
+  private
+
+  def published_authors
+    Author.published
+  end
+end
+```
+
 Pages
 -----
 

--- a/core/app/helpers/brightcontent/base_helper.rb
+++ b/core/app/helpers/brightcontent/base_helper.rb
@@ -4,8 +4,8 @@ module Brightcontent
       ViewLookup::ListField.new(self, item: item, field: field).call
     end
 
-    def render_filter_field(form, field)
-      ViewLookup::FilterField.new(self, field: field, form: form).call
+    def render_filter_field(form, field, options)
+      ViewLookup::FilterField.new(self, field: field, form: form, options: options).call
     end
 
     def render_form_field(form, field)

--- a/core/app/helpers/brightcontent/base_helper.rb
+++ b/core/app/helpers/brightcontent/base_helper.rb
@@ -17,5 +17,19 @@ module Brightcontent
     rescue ActionView::MissingTemplate
       nil
     end
+
+    # Returns filter field definitions as a nested array.
+    #
+    #  [:foo, { bar: { as: :select }, qux: { as: :string } }]
+    #
+    # Becomes:
+    #
+    #  [[:foo], [:bar, { as: :select }], [:qux, { as: :string }]]
+    #
+    def normalized_filter_fields
+      filter_fields.flat_map do |field|
+        field.is_a?(Hash) ? field.to_a : [[field]]
+      end
+    end
   end
 end

--- a/core/app/views/brightcontent/base/_list_filters.html.erb
+++ b/core/app/views/brightcontent/base/_list_filters.html.erb
@@ -1,7 +1,7 @@
 <% if filter_fields.present? %>
   <div class="panel-body">
     <%= search_form_for ransack_search, class: "form-inline" do |form| %>
-      <% filter_fields_with_options.each do |field, options| %>
+      <% normalized_filter_fields.each do |field, options| %>
         <%= render_filter_field form, field, options %>
       <% end %>
       <%= form.submit class: "btn btn-default btn-sm" %>

--- a/core/app/views/brightcontent/base/_list_filters.html.erb
+++ b/core/app/views/brightcontent/base/_list_filters.html.erb
@@ -1,10 +1,8 @@
 <% if filter_fields.present? %>
   <div class="panel-body">
     <%= search_form_for ransack_search, class: "form-inline" do |form| %>
-      <% filter_fields.each do |field| %>
-        <div class="form-group">
-          <%= render_filter_field form, field %>
-        </div>
+      <% filter_fields_with_options.each do |field, options| %>
+        <%= render_filter_field form, field, options %>
       <% end %>
       <%= form.submit class: "btn btn-default btn-sm" %>
     <% end %>

--- a/core/lib/brightcontent/base_controller_ext/fields.rb
+++ b/core/lib/brightcontent/base_controller_ext/fields.rb
@@ -12,7 +12,6 @@ module Brightcontent
             helper_method :#{name}
           RUBY
         end
-        helper_method :filter_fields_with_options
       end
 
       protected
@@ -23,20 +22,6 @@ module Brightcontent
 
       def filter_fields
         []
-      end
-
-      # Returns filter field definitions as a nested array.
-      #
-      #  [:foo, { bar: { as: :select }, qux: { as: :string } }]
-      #
-      # Becomes:
-      #
-      #  [[:foo], [:bar, { as: :select }], [:qux, { as: :string }]]
-      #
-      def filter_fields_with_options
-        filter_fields.map do |field, result|
-          field.is_a?(Hash) ? field.to_a : [[field]]
-        end.flatten(1)
       end
 
       def form_fields

--- a/core/lib/brightcontent/base_controller_ext/fields.rb
+++ b/core/lib/brightcontent/base_controller_ext/fields.rb
@@ -12,6 +12,7 @@ module Brightcontent
             helper_method :#{name}
           RUBY
         end
+        helper_method :filter_fields_with_options
       end
 
       protected
@@ -22,6 +23,20 @@ module Brightcontent
 
       def filter_fields
         []
+      end
+
+      # Returns filter field definitions as a nested array.
+      #
+      #  [:foo, { bar: { as: :select }, qux: { as: :string } }]
+      #
+      # Becomes:
+      #
+      #  [[:foo], [:bar, { as: :select }], [:qux, { as: :string }]]
+      #
+      def filter_fields_with_options
+        filter_fields.map do |field, result|
+          field.is_a?(Hash) ? field.to_a : [[field]]
+        end.flatten(1)
       end
 
       def form_fields

--- a/core/lib/brightcontent/core.rb
+++ b/core/lib/brightcontent/core.rb
@@ -1,3 +1,6 @@
+# Make SimpleForm helpers available in Ransack's search form:
+# https://github.com/activerecord-hackery/ransack#using-simpleform
+#
 ENV['RANSACK_FORM_BUILDER'] ||= '::SimpleForm::FormBuilder'
 
 require "coffee_script"

--- a/core/lib/brightcontent/core.rb
+++ b/core/lib/brightcontent/core.rb
@@ -1,3 +1,5 @@
+ENV['RANSACK_FORM_BUILDER'] ||= '::SimpleForm::FormBuilder'
+
 require "coffee_script"
 require "bootstrap-sass"
 require "bootstrap-wysihtml5-rails"

--- a/core/lib/brightcontent/view_lookup/base.rb
+++ b/core/lib/brightcontent/view_lookup/base.rb
@@ -7,7 +7,7 @@ module Brightcontent
 
       def initialize(view_context, options)
         @view_context = view_context
-        @options = options
+        @options = options.symbolize_keys
       end
 
       def call

--- a/core/lib/brightcontent/view_lookup/filter_field.rb
+++ b/core/lib/brightcontent/view_lookup/filter_field.rb
@@ -8,6 +8,10 @@ module Brightcontent
 
       private
 
+      def controller
+        view_context.controller
+      end
+
       def field?
         resource_class.column_names.include? options[:field].to_s
       end
@@ -45,8 +49,8 @@ module Brightcontent
 
         if collection.respond_to?(:call)
           collection.call
-        elsif collection.is_a?(Symbol) && view_context.respond_to?(collection)
-          view_context.send(collection)
+        elsif collection.is_a?(Symbol) && controller.respond_to?(collection, true)
+          controller.send(collection)
         elsif collection
           collection
         elsif as_collection?

--- a/core/spec/dummy/app/controllers/brightcontent/blogs_controller.rb
+++ b/core/spec/dummy/app/controllers/brightcontent/blogs_controller.rb
@@ -1,3 +1,3 @@
 class Brightcontent::BlogsController < Brightcontent::BaseController
-  filter_fields %w[featured author]
+  filter_fields :featured, :author, name: { as: :string }
 end

--- a/core/spec/dummy/app/models/author.rb
+++ b/core/spec/dummy/app/models/author.rb
@@ -1,7 +1,3 @@
 class Author < ActiveRecord::Base
   has_many :blogs
-
-  def to_s
-    name
-  end
 end

--- a/core/spec/features/resources_index_spec.rb
+++ b/core/spec/features/resources_index_spec.rb
@@ -41,6 +41,14 @@ feature "Resources index" do
     page_should_have_n_rows 9
   end
 
+  scenario "Filter by name" do
+    given_2_blog_items_with_different_names
+    visit_blogs_page
+    fill_in "Name", with: "Foo"
+    click_button "Search"
+    page_should_have_n_rows 1
+  end
+
   def visit_blogs_page
     click_link "Blogs"
   end
@@ -70,5 +78,10 @@ feature "Resources index" do
 
   def given_10_per_page
     Brightcontent::BlogsController.class_eval { per_page 10 }
+  end
+
+  def given_2_blog_items_with_different_names
+    create :blog, name: "Foo"
+    create :blog, name: "Bar"
   end
 end

--- a/core/spec/features/resources_index_spec.rb
+++ b/core/spec/features/resources_index_spec.rb
@@ -44,7 +44,7 @@ feature "Resources index" do
   scenario "Filter by name" do
     given_2_blog_items_with_different_names
     visit_blogs_page
-    fill_in "Name", with: "Foo"
+    fill_in "Name", with: "oo"
     click_button "Search"
     page_should_have_n_rows 1
   end


### PR DESCRIPTION
Adds the ability to customize filters, alike ActiveAdmin, using the power of SimpleForm.

### Defining filters

`filter_fields` now also accepts filter options through a hash:
```ruby
# Current syntax hasn't changed:
filter_fields "author", "name"

# You can also use symbols now:
filter_fields :author, :name

# Passing options:
filter_fields author: { ... }, name: { ... }

# Combining both styles is possible:
filter_fields :author, name: { ... }
```

### Options

All options for `SimpleForm::FormBuilder#input` are accepted and work as expected, such as `:as`, `:input_html`, and `:label_method`.

#### Changed and additional options

##### <tt>:collection</tt>

As SimpleForm's <tt>:collection</tt> option, but also accepts a Proc or method name as a symbol. The default hasn't changed and is only applied if a collection type filter is used (eg. `:select`).

##### <tt>:predicate</tt>

Lets you specify the Ransack search predicate to be used. Defaults to "cont" for string type filters (`:string` or `:search`) and to "eq" for all other types.

### Examples

```ruby
class BlogsController < Brightcontent::BaseController
  # Free form text filter, returns all blogs where name contains given query:
  filter_fields name: { as: :string, predicate: "cont" }
  
  # Same as above:
  filter_fields name: { as: :string }

  # Customized label:
  filter_fields author: { label: "Written by" }

  # Select filter with custom options:
  filter_fields name: { collection: %w(Arthur Slartibartfast Trinity) } 

  # Belongs-to filter with custom options:
  filter_fields author: { collection: ->{ Author.order(:name) }, label_method: :display_name }

  # Or by means of a controller method:
  filter_fields author: { collection: :published_authors }

  # Or even a fully customized filter, using a fictitious custom SimpleForm input field:
  filter_fields author: { as: :remote_select, url: "/authors.json?order=name" }

  private

  def published_authors
    Author.published
  end
end
```