### PR TITLE
Avoid a filter predicate by setting :predicate to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Extends SimpleForm's `:collection` option. It also accepts a Proc, or method nam
 
 ##### <tt>:predicate</tt>
 
-Allows for specifying the Ransack search predicate to be used. Defaults to "cont" (contains) for string type filters (`:string` or `:search`) and to "eq" (equals) for all other types. For more information refer to [Ransack's documentation](https://github.com/activerecord-hackery/ransack/wiki/Basic-Searching).
+Allows for specifying the Ransack search predicate to be used. Set it to `false` to avoid a predicate. Defaults to "cont" (contains) for string type filters (`:string` or `:search`) and to "eq" (equals) for all other types. It defaults to `false` if the field name refers to [a ransackable scope](https://github.com/activerecord-hackery/ransack#using-scopesclass-methods). For more information refer to [Ransack's documentation](https://github.com/activerecord-hackery/ransack/wiki/Basic-Searching).
 
 ### Examples
 
@@ -116,10 +116,21 @@ class BlogsController < Brightcontent::BaseController
   # Filter by start date:
   filter_fields created_at: { as: :date, predicate: "gteq", label: "Posted since" }
 
+  # Filter by scope (see definition of Blog below):
+  filter_fields exclude_inactive: { as: :select, collection: [["Yes", true], ["No", false]] }
+
   private
 
   def published_authors
     Author.published
+  end
+end
+
+def Blog < ActiveRecord::Base
+  scope :exclude_inactive, ->{ where(active: true) }
+
+  def self.ransackable_scopes(auth_object = nil)
+    [:exclude_inactive]
   end
 end
 ```

--- a/core/spec/dummy/app/controllers/brightcontent/blogs_controller.rb
+++ b/core/spec/dummy/app/controllers/brightcontent/blogs_controller.rb
@@ -1,3 +1,3 @@
 class Brightcontent::BlogsController < Brightcontent::BaseController
-  filter_fields :featured, :author, name: { as: :string }, name_or_comments_text: { label: "Find" }
+  filter_fields :featured, :author, name: { as: :string }, name_or_comments_text: { label: "Find" }, exclude_inactive: { as: :boolean }
 end

--- a/core/spec/dummy/app/models/blog.rb
+++ b/core/spec/dummy/app/models/blog.rb
@@ -1,5 +1,11 @@
 class Blog < ActiveRecord::Base
   belongs_to :author
   has_many :comments
+
   scope :featured, ->{ where(:featured => true) }
+  scope :exclude_inactive, ->{ where(active: true) }
+
+  def self.ransackable_scopes(auth = nil)
+    [:exclude_inactive]
+  end
 end

--- a/core/spec/dummy/db/migrate/20150219130156_add_active_to_blogs.rb
+++ b/core/spec/dummy/db/migrate/20150219130156_add_active_to_blogs.rb
@@ -1,0 +1,5 @@
+class AddActiveToBlogs < ActiveRecord::Migration
+  def change
+    add_column :blogs, :active, :boolean, default: true
+  end
+end

--- a/core/spec/features/resources_index_spec.rb
+++ b/core/spec/features/resources_index_spec.rb
@@ -57,6 +57,15 @@ feature "Resources index" do
     page_should_have_n_rows 2
   end
 
+  scenario "Filter by exclude_inactive scope" do
+    given_an_active_and_inactive_blog
+    visit_blogs_page
+    page_should_have_n_rows 2
+    check "Exclude inactive"
+    click_button "Search"
+    page_should_have_n_rows 1
+  end
+
   def visit_blogs_page
     click_link "Blogs"
   end
@@ -97,5 +106,10 @@ feature "Resources index" do
     create :blog, name: "Foo"
     create :blog, name: "Bar"
     create :comment, text: "Doodles"
+  end
+
+  def given_an_active_and_inactive_blog
+    create :blog, name: "Foo", active: false
+    create :blog, name: "Bar", active: true
   end
 end

--- a/core/spec/lib/brightcontent/model_extensions_spec.rb
+++ b/core/spec/lib/brightcontent/model_extensions_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Brightcontent
   describe ModelExtensions do
-    let(:columns) {  ["id", "name", "body", "created_at", "updated_at", "featured", "author_id"] }
+    let(:columns) {  ["id", "name", "body", "created_at", "updated_at", "featured", "author_id", "active"] }
     subject(:blog) { Blog }
     its(:brightcontent_columns) { should eq columns }
 


### PR DESCRIPTION
By setting `filter_fields`'s `:predicate` option to `false` (or anything falsy) no predicate will be appended to the filter field's name.

This enables users to make use of [ransackable scopes](https://github.com/activerecord-hackery/ransack#using-scopesclass-methods) where the filter input name would reflect a named scope without a predicate.

For convenience `:predicate` will default to `false` when it detects a ransackable scope.

See new specs and updated README for examples.

