### PR TITLE
Clarify input_name method

### DIFF
--- a/core/lib/brightcontent/view_lookup/filter_field.rb
+++ b/core/lib/brightcontent/view_lookup/filter_field.rb
@@ -32,7 +32,11 @@ module Brightcontent
       end
 
       def input_name
-        [field_name.to_s, predicate].reject(&:!).join("_")
+        if predicate
+          "#{field_name}_#{predicate}"
+        else
+          field_name.to_s
+        end
       end
 
       def filter_options


### PR DESCRIPTION
Fixes clever-but-unreadable method introduced in #39.