### PR TITLE
Add adjustable page sizes to pagination.

### DIFF
--- a/core/app/views/brightcontent/base/_page_sizes.html.erb
+++ b/core/app/views/brightcontent/base/_page_sizes.html.erb
@@ -1,0 +1,9 @@
+<% if sizes.try(:any?) %>
+  <ul class="pagination page-sizes pull-left">
+    <% sizes.each do |size| %>
+      <li class="<%= :active if size == current_size %>">
+        <%= link_to size, { per_page: size, page: corrected_page(size) } %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/core/app/views/brightcontent/base/index.html.erb
+++ b/core/app/views/brightcontent/base/index.html.erb
@@ -19,5 +19,7 @@
 </div>
 
 <div class="panel-footer panel-footer-pagination">
-  <%= will_paginate collection, renderer: BootstrapPagination::Rails %>
+  <%= render partial: "page_sizes",
+    locals: { sizes: per_page_sizes, current_size: items_per_page } %>
+  <%= will_paginate collection, class: :pages, renderer: BootstrapPagination::Rails %>
 </div>

--- a/core/lib/brightcontent/base_controller_ext/pagination.rb
+++ b/core/lib/brightcontent/base_controller_ext/pagination.rb
@@ -5,21 +5,61 @@ module Brightcontent
     module Pagination
       extend ActiveSupport::Concern
 
+      included do
+        helper_method :items_per_page
+        helper_method :current_page
+        helper_method :per_page_sizes
+        helper_method :corrected_page
+      end
+
       module ClassMethods
         def per_page_count
-          @per_page_count ||= 30
+          @per_page_count =
+            @per_page_sizes.try(:any?) ? @per_page_sizes[0] : (@per_page_count || 30)
         end
 
         def per_page(number)
           @per_page_count = number
         end
+
+        def page_size_options(sizes)
+          return unless sizes.is_a? Array
+          @per_page_sizes =
+            sizes.select { |size| size.is_a?(Integer) && size > 0 }
+        end
+
+        def per_page_sizes
+          @per_page_sizes ||= []
+        end
       end
 
       private
 
+      def items_per_page
+        per_page = params[:per_page].try(:to_i)
+        @items_per_page =
+          if per_page && self.class.per_page_sizes.include?(per_page)
+            per_page.to_i
+          else
+            self.class.per_page_count
+          end
+      end
+
+      def current_page
+        params[:page].try(:to_i) || 1
+      end
+
+      def corrected_page(size)
+        (current_page - 1) * items_per_page / size + 1
+      end
+
+      def per_page_sizes
+        self.class.per_page_sizes
+      end
+
       def end_of_association_chain
-        if action_name == "index" && self.class.per_page_count > 0
-          super.paginate(page: params[:page], per_page: self.class.per_page_count)
+        if action_name == "index" && items_per_page > 0
+          super.paginate(page: params[:page], per_page: items_per_page)
         else
           super
         end


### PR DESCRIPTION
Add adjustable page sizes for pagination.

If `page_size_options` is set in a controller, the index view will get page size options next to the page selection.

Example for `page_size_options`:
``` ruby
self.class.page_size_options [10, 30, 50, 100, 200]
```

Invalid entries in the array will be ignored, so `["a", 20, 30, nil, 40]` will turn into `[20, 30, 40]`