### PR TITLE
Adjustable pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,3 @@ page_size_options [10, 25, 50, 100]
 
 This will set the default page size to `10` and inject 4 page size options in
 the index views. The `per_page` value (if provided), will be ignored.
-
-Invalid options will be ignored, so `page_size_options ["a", 10, 25, nil, 50, 100]`
-will lead to the same result.

--- a/README.md
+++ b/README.md
@@ -145,3 +145,20 @@ This adds an extra layer on top of your existing routes. However when there aren
 ```ruby
 get "*path" => "pages#show", constraints: Brightcontent::Pages::PathConstraint.new
 ```
+
+Pagination
+----------
+
+The number of pages can be set in a controller by calling `per_page 50`.
+
+If multiple page sizes are preferred, you can provide those sizes with
+
+``` ruby
+page_size_options [10, 25, 50, 100]
+```
+
+This will set the default page size to `10` and inject 4 page size options in
+the index views. The `per_page` value (if provided), will be ignored.
+
+Invalid options will be ignored, so `page_size_options ["a", 10, 25, nil, 50, 100]`
+will lead to the same result.

--- a/core/app/views/brightcontent/base/_list_filters.html.erb
+++ b/core/app/views/brightcontent/base/_list_filters.html.erb
@@ -1,6 +1,7 @@
 <% if filter_fields.present? %>
   <div class="panel-body">
     <%= search_form_for ransack_search, class: "form-inline" do |form| %>
+      <%= hidden_field_tag :per_page, items_per_page %>
       <% normalized_filter_fields.each do |field, options| %>
         <%= render_filter_field form, field, options %>
       <% end %>

--- a/core/app/views/brightcontent/base/_page_sizes.html.erb
+++ b/core/app/views/brightcontent/base/_page_sizes.html.erb
@@ -1,7 +1,7 @@
-<% if sizes.length > 1 && collection.count > sizes.min %>
+<% if page_sizes.length > 1 && collection.count > page_sizes.min %>
   <ul class="pagination page-sizes pull-left">
-    <% sizes.each do |size| %>
-      <li class="<%= :active if size == current_size %>">
+    <% page_sizes.each do |size| %>
+      <li class="<%= :active if size == items_per_page %>">
         <%= link_to size, params.merge({ per_page: size, page: corrected_page(size) }) %>
       </li>
     <% end %>

--- a/core/app/views/brightcontent/base/_page_sizes.html.erb
+++ b/core/app/views/brightcontent/base/_page_sizes.html.erb
@@ -1,0 +1,9 @@
+<% if sizes.try(:any?) %>
+  <ul class="pagination page-sizes pull-left">
+    <% sizes.each do |size| %>
+      <li class="<%= :active if size == current_size %>">
+        <%= link_to size, { per_page: size, page: corrected_page(size) } %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/core/app/views/brightcontent/base/_page_sizes.html.erb
+++ b/core/app/views/brightcontent/base/_page_sizes.html.erb
@@ -1,4 +1,4 @@
-<% if sizes.try(:any?) %>
+<% if sizes.length > 1 && collection.count > sizes.min %>
   <ul class="pagination page-sizes pull-left">
     <% sizes.each do |size| %>
       <li class="<%= :active if size == current_size %>">

--- a/core/app/views/brightcontent/base/_page_sizes.html.erb
+++ b/core/app/views/brightcontent/base/_page_sizes.html.erb
@@ -2,7 +2,7 @@
   <ul class="pagination page-sizes pull-left">
     <% sizes.each do |size| %>
       <li class="<%= :active if size == current_size %>">
-        <%= link_to size, { per_page: size, page: corrected_page(size) } %>
+        <%= link_to size, params.merge({ per_page: size, page: corrected_page(size) }) %>
       </li>
     <% end %>
   </ul>

--- a/core/app/views/brightcontent/base/index.html.erb
+++ b/core/app/views/brightcontent/base/index.html.erb
@@ -19,7 +19,6 @@
 </div>
 
 <div class="panel-footer panel-footer-pagination">
-  <%= render partial: "page_sizes",
-    locals: { sizes: per_page_sizes, current_size: items_per_page } %>
+  <%= render partial: "page_sizes" %>
   <%= will_paginate collection, class: :pages, renderer: BootstrapPagination::Rails %>
 </div>

--- a/core/app/views/brightcontent/base/index.html.erb
+++ b/core/app/views/brightcontent/base/index.html.erb
@@ -19,5 +19,7 @@
 </div>
 
 <div class="panel-footer panel-footer-pagination">
-  <%= will_paginate collection, renderer: BootstrapPagination::Rails %>
+  <%= render partial: "page_sizes",
+    locals: { sizes: per_page_sizes, current_size: items_per_page } %>
+  <%= will_paginate collection, class: :pages, renderer: BootstrapPagination::Rails %>
 </div>

--- a/core/lib/brightcontent/base_controller_ext/pagination.rb
+++ b/core/lib/brightcontent/base_controller_ext/pagination.rb
@@ -8,28 +8,26 @@ module Brightcontent
       included do
         helper_method :items_per_page
         helper_method :current_page
-        helper_method :per_page_sizes
+        helper_method :page_sizes
         helper_method :corrected_page
       end
 
       module ClassMethods
         def per_page_count
-          @per_page_count =
-            @per_page_sizes.try(:any?) ? @per_page_sizes[0] : (@per_page_count || 30)
+          @page_size = page_sizes.min
         end
 
         def per_page(number)
-          @per_page_count = number
+          @page_sizes = [number]
         end
 
         def page_size_options(sizes)
           return unless sizes.is_a? Array
-          @per_page_sizes =
-            sizes.select { |size| size.is_a?(Integer) && size > 0 }
+          @page_sizes = sizes
         end
 
-        def per_page_sizes
-          @per_page_sizes ||= []
+        def page_sizes
+          @page_sizes ||= [30]
         end
       end
 
@@ -38,7 +36,7 @@ module Brightcontent
       def items_per_page
         per_page = params[:per_page].try(:to_i)
         @items_per_page =
-          if per_page && self.class.per_page_sizes.include?(per_page)
+          if per_page && page_sizes.include?(per_page)
             per_page.to_i
           else
             self.class.per_page_count
@@ -53,8 +51,8 @@ module Brightcontent
         (current_page - 1) * items_per_page / size + 1
       end
 
-      def per_page_sizes
-        self.class.per_page_sizes
+      def page_sizes
+        self.class.page_sizes
       end
 
       def end_of_association_chain

--- a/core/lib/brightcontent/base_controller_ext/pagination.rb
+++ b/core/lib/brightcontent/base_controller_ext/pagination.rb
@@ -5,21 +5,61 @@ module Brightcontent
     module Pagination
       extend ActiveSupport::Concern
 
+      included do
+        helper_method :items_per_page
+        helper_method :current_page
+        helper_method :per_page_sizes
+        helper_method :corrected_page
+      end
+
       module ClassMethods
         def per_page_count
-          @per_page_count ||= 30
+          @per_page_count =
+            @per_page_sizes.try(:any?) ? @per_page_sizes[0] : (@per_page_count || 30)
         end
 
         def per_page(number)
           @per_page_count = number
         end
+
+        def page_size_options(sizes)
+          return unless sizes.is_a? Array
+          @per_page_sizes =
+            sizes.select { |size| size.is_a?(Integer) && size > 0 }
+        end
+
+        def per_page_sizes
+          @per_page_sizes ||= []
+        end
       end
 
       private
 
+      def items_per_page
+        per_page = params[:per_page].try(:to_i)
+        @items_per_page =
+          if per_page && self.class.per_page_sizes.include?(per_page)
+            per_page.to_i
+          else
+            self.class.per_page_count
+          end
+      end
+
+      def current_page
+        params[:page].try(:to_i) || 1
+      end
+
+      def corrected_page(size)
+        (current_page - 1) * items_per_page / size + 1
+      end
+
+      def per_page_sizes
+        self.class.per_page_sizes
+      end
+
       def end_of_association_chain
-        if action_name == "index" && self.class.per_page_count > 0
-          super.paginate(page: params[:page], per_page: self.class.per_page_count)
+        if action_name == "index" && items_per_page > 0
+          super.paginate(page: params[:page], per_page: items_per_page)
         else
           super
         end

--- a/core/spec/features/resources_index_spec.rb
+++ b/core/spec/features/resources_index_spec.rb
@@ -161,16 +161,6 @@ feature "Resources index" do
 
       page.should_not have_css(".pagination.page-sizes")
     end
-
-    context "with invalid entries in page sizes list" do
-      scenario "shows the valid options" do
-        given_page_sizes ["a", 2, 5, nil, 8]
-        given_blog_items
-        visit_blogs_page
-
-        page.should have_css(".pagination.page-sizes li", count: 3)
-      end
-    end
   end
 
   def visit_blogs_page

--- a/core/spec/features/resources_index_spec.rb
+++ b/core/spec/features/resources_index_spec.rb
@@ -120,6 +120,48 @@ feature "Resources index" do
       end
     end
 
+    scenario "retains page size after applying filter" do
+      given_page_sizes [2, 4, 8]
+      given_blog_items 9
+      visit_blogs_page
+      within ".pagination.page-sizes" do
+        click_link "4"
+      end
+
+      fill_in "Name", with: "Blog"
+      click_button "Search"
+
+      within ".pagination.page-sizes .active" do
+        page.should have_content "4"
+      end
+    end
+
+    scenario "retains filter after applying page size" do
+      given_page_sizes [2, 4, 8]
+      given_blog_items 14
+      visit_blogs_page
+      fill_in "Name", with: "Blog 1"
+      click_button "Search"
+
+      # 3 numbered links and previous/next links
+      page.should have_css(".pagination.pages li", count: 5)
+
+      within ".pagination.page-sizes" do
+        click_link "4"
+      end
+
+      # 2 numbered links and previous/next links
+      page.should have_css(".pagination.pages li", count: 4)
+    end
+
+    scenario "hides page size options when there is only a single page" do
+      given_page_sizes [5, 6, 7]
+      given_blog_items 4
+      visit_blogs_page
+
+      page.should_not have_css(".pagination.page-sizes")
+    end
+
     context "with invalid entries in page sizes list" do
       scenario "shows the valid options" do
         given_page_sizes ["a", 2, 5, nil, 8]
@@ -183,6 +225,6 @@ feature "Resources index" do
   end
 
   def given_blog_items(num = 10)
-    num.times { create [:blog, :featured_blog].sample }
+    num.times { |num| create [:blog, :featured_blog].sample, name: "Blog #{num}" }
   end
 end


### PR DESCRIPTION
Add adjustable page sizes for pagination.

If `page_size_options` is set in a controller, the index view will get page size options next to the page selection.

Example for `page_size_options`:
``` ruby
page_size_options [10, 30, 50, 100, 200]
```

- [x] Fix bug where filters are cleared on page_size change
- [x] Fix bug where page_size is cleared on filter change
- [x] Fix bug where page_size selection is visible on empty list