### PR TITLE
Fix pagination for grouped collections

### DIFF
--- a/core/app/views/brightcontent/base/_page_sizes.html.erb
+++ b/core/app/views/brightcontent/base/_page_sizes.html.erb
@@ -1,4 +1,4 @@
-<% if page_sizes.length > 1 && collection.count > page_sizes.min %>
+<% if page_sizes_visible?(collection) %>
   <ul class="pagination page-sizes pull-left">
     <% page_sizes.each do |size| %>
       <li class="<%= :active if size == items_per_page %>">

--- a/core/lib/brightcontent/base_controller_ext/pagination.rb
+++ b/core/lib/brightcontent/base_controller_ext/pagination.rb
@@ -10,6 +10,7 @@ module Brightcontent
         helper_method :current_page
         helper_method :page_sizes
         helper_method :corrected_page
+        helper_method :page_sizes_visible?
       end
 
       module ClassMethods
@@ -41,6 +42,16 @@ module Brightcontent
           else
             self.class.per_page_count
           end
+      end
+
+      def page_sizes_visible?(collection)
+        total_entries = collection.count
+
+        if total_entries.respond_to?(:size) && !total_entries.is_a?(Integer)
+          total_entries = total_entries.size
+        end
+
+        page_sizes.length > 1 && total_entries > page_sizes.min
       end
 
       def current_page

--- a/core/spec/dummy/app/controllers/brightcontent/grouped_blogs_controller.rb
+++ b/core/spec/dummy/app/controllers/brightcontent/grouped_blogs_controller.rb
@@ -1,0 +1,5 @@
+class Brightcontent::GroupedBlogsController < Brightcontent::BaseController
+  def collection
+    super.group(:author_id)
+  end
+end

--- a/core/spec/dummy/app/models/grouped_blog.rb
+++ b/core/spec/dummy/app/models/grouped_blog.rb
@@ -1,0 +1,9 @@
+class GroupedBlog < ActiveRecord::Base
+  belongs_to :author
+
+  scope :exclude_inactive, ->{ where(active: true) }
+
+  def self.ransackable_scopes(auth = nil)
+    [:exclude_inactive]
+  end
+end

--- a/core/spec/dummy/config/routes.rb
+++ b/core/spec/dummy/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
     resources :blogs do
       resources :comments
     end
+
+    resources :grouped_blogs
   end
 end

--- a/core/spec/dummy/db/migrate/20160623142310_create_grouped_blogs.rb
+++ b/core/spec/dummy/db/migrate/20160623142310_create_grouped_blogs.rb
@@ -1,0 +1,12 @@
+class CreateGroupedBlogs < ActiveRecord::Migration
+  def change
+    create_table :grouped_blogs do |t|
+      t.string :name
+      t.text :body
+      t.boolean :active, default: true
+      t.column :author_id, :integer
+
+      t.timestamps
+    end
+  end
+end

--- a/core/spec/factories.rb
+++ b/core/spec/factories.rb
@@ -19,6 +19,11 @@ FactoryGirl.define do
     end
   end
 
+  factory :grouped_blog do
+    name "Blogname"
+    body "Inhoud"
+  end
+
   factory :author do
     factory :author_with_blogs do
       transient do
@@ -26,6 +31,15 @@ FactoryGirl.define do
       end
       after(:create) do |author, evaluator|
         create_list(:blog, evaluator.blogs_count, author: author)
+      end
+
+    end
+    factory :author_with_grouped_blogs do
+      transient do
+        blogs_count 5
+      end
+      after(:create) do |author, evaluator|
+        create_list(:grouped_blog, evaluator.blogs_count, author: author)
       end
     end
   end

--- a/core/spec/features/grouped_resources_index_spec.rb
+++ b/core/spec/features/grouped_resources_index_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+feature "Grouped resources index" do
+  background do
+    sign_in
+  end
+
+  scenario "Visit the index view of resource" do
+    given_authors_with_blogs(authors: 3, blogs: 2)
+    given_page_sizes [2, 3]
+
+    visit_grouped_blogs_page
+
+    page_should_have_n_rows 2
+
+    # 2 numbered links and previous/next links
+    page.should have_css(".pagination.pages li", count: 4)
+  end
+
+  def visit_grouped_blogs_page
+    click_link "Grouped blogs"
+  end
+
+  def given_authors_with_blogs(authors: 2, blogs: 5)
+    authors.times do |num|
+      create(:author_with_grouped_blogs, blogs_count: blogs, name: "Blogger #{num}")
+    end
+  end
+
+  def given_page_sizes(sizes = [2, 6, 10])
+    Brightcontent::GroupedBlogsController.class_eval { page_size_options sizes }
+  end
+
+  def page_should_have_n_rows(n)
+    page.should have_css("tbody tr", :count => n)
+  end
+end


### PR DESCRIPTION
We have encountered a bug in the current implementation of adjustable pagination.

When a model is queried with a `.group` call, the result of `count` is a `Hash` with count per group, instead of just a number.

This PR fixes the issue, the solution is based on the solution from will_paginate:
https://github.com/mislav/will_paginate/blob/master/lib/will_paginate/active_record.rb#L73
